### PR TITLE
Add support for the SPI flash W25Q32JV from Winbond.

### DIFF
--- a/sys/dev/flash/mx25l.c
+++ b/sys/dev/flash/mx25l.c
@@ -127,6 +127,7 @@ struct mx25l_flash_ident flash_devices[] = {
 	{ "w25x32",	0xef, 0x3016, 64 * 1024, 64, FL_ERASE_4K },
 	{ "w25x64",	0xef, 0x3017, 64 * 1024, 128, FL_ERASE_4K },
 	{ "w25q32",	0xef, 0x4016, 64 * 1024, 64, FL_ERASE_4K },
+	{ "w25q32jv",	0xef, 0x7016, 64 * 1024, 64, FL_ERASE_4K },
 	{ "w25q64",	0xef, 0x4017, 64 * 1024, 128, FL_ERASE_4K },
 	{ "w25q64bv",	0xef, 0x4017, 64 * 1024, 128, FL_ERASE_4K },
 	{ "w25q128",	0xef, 0x4018, 64 * 1024, 256, FL_ERASE_4K },


### PR DESCRIPTION
Tested on production SG-3100.

(cherry picked from commit 276b374d3d1baa24389227e6c6aa350654503ef2)